### PR TITLE
Allow the role to support check mode

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -8,6 +8,7 @@
 - name: Check for Tuned legacy
   shell: tuned --version &> /dev/null || echo -n "legacy"
   register: tversion
+  check_mode: no
 
 - set_fact:
     tuned_legacy: "{{ (tversion.stdout == 'legacy') | ternary(true,false) }}"
@@ -20,7 +21,8 @@
 - name: Get Tuned recommended profile
   shell: tuned-adm recommend 2> /dev/null || echo -n " *fail"
   register: recommend
-
+  check_mode: no
+  
 - set_fact:
     tuned_recommended_profile: "{{ (recommend.stdout == ' *fail') | ternary('default',recommend.stdout) }}"
 


### PR DESCRIPTION
set "check_mode: no" allow tasks to run even on check mode  this prevent "set_fact" tasks from failure.

TASK [linux-system-roles.tuned : set_fact] **************************************************************
fatal: [servera]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'stdout'\n\nThe error appears to be in '/home/student/.ansible/roles/linux-system-roles.tuned/tasks/main.yaml': line 25, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- set_fact:\n  ^ here\n"}
