### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/tuned-main.conf.j2
+++ b/templates/tuned-main.conf.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }
+{{ "system_role:tuned" | comment(prefix="", postfix="") }}
 
 daemon = {{ daemon }}
 dynamic_tuning = {{ dynamic_tuning }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:tuned
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.
